### PR TITLE
Updating cyberark_credential module for Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Provided Modules
 - **cyberark_user**: Module for CyberArk User Management using Privileged Account Security Web Services SDK
 - **cyberark_credential**: Module for CyberArk credential retrieval using Cyberark Central Credential Provider. 
  
-**NOTE**: For access to the cyberark_credential functionality, the **library/cyberark_credential.py** file will need to be added to the Ansible modules directory of the Ansible server.
+**NOTE**: For access to the cyberark_credential functionality, the **library/cyberark_credential.py** file will need to be added to the Ansible modules directory of the Ansible server, e.g. **~/.ansible/plugins/modules/** or **/usr/share/ansible/plugins/modules/**
 
 
 Example Playbook
@@ -244,13 +244,13 @@ Example Playbook
         api_base_url: "http://10.10.0.1"
         app_id: "TestID"
         query: "Safe=test;UserName=admin"
-      register: {{ result }}
+      register: result
       no_log: true
 
 
     - name: Debug message
       debug: 
-        var: {{ result }}
+        var: result
 ```
 
 

--- a/library/cyberark_credential.py
+++ b/library/cyberark_credential.py
@@ -183,7 +183,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 import json
-import urllib
+# Python3 split urllib into urllib.request, urllib.parse, and urllib.error
+import urllib.parse
 try:
     import httplib
 except ImportError:
@@ -210,10 +211,10 @@ def retrieveCredential(module):
     if "client_key" in module.params:
         client_key = module.params["client_key"]
 
-    end_point = "/AIMWebService/api/Accounts?AppId=%s&Query=%s&ConnectionTimeout=%s&QueryFormat=%s&FailRequestOnPasswordChange=%s" % (urllib.quote(app_id), urllib.quote(query), connection_timeout, query_format, fail_request_on_password_change)
+    end_point = "/AIMWebService/api/Accounts?AppId=%s&Query=%s&ConnectionTimeout=%s&QueryFormat=%s&FailRequestOnPasswordChange=%s" % (urllib.parse.quote(app_id), urllib.parse.quote(query), connection_timeout, query_format, fail_request_on_password_change)
     
     if "reason" in module.params and module.params["reason"] != None:
-        reason = urllib.quote(module.params["reason"])
+        reason = urllib.parse.quote(module.params["reason"])
         end_point = end_point + "&reason=%s" % reason
 
     result = None


### PR DESCRIPTION
Python3 doesn't have `urllib.quote`, you must use `urllib.parse.quote` instead. Updating the module so it can be used in Python3.